### PR TITLE
added static type for Parse.User unsafeCurrentUser() method

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -690,6 +690,7 @@ subscription.on('close', () => {});
         static requestPasswordReset(email: string, options?: SuccessFailureOptions): Promise<User>;
         static extend(protoProps?: any, classProps?: any): any;
         static hydrate(userJSON: any): Promise<User>;
+        static enableUnsafeCurrentUser(): void;
 
         signUp(attrs?: any, options?: SignUpOptions): Promise<this>;
         logIn(options?: SuccessFailureOptions): Promise<this>;


### PR DESCRIPTION
Parse.User has a static method called `unsafeCurrentUser`, but it was missing from this ts file.

Docs on unsafeCurrentUser method:
https://parseplatform.org/Parse-SDK-JS/api/v1.11.1/Parse.User.html#.enableUnsafeCurrentUser